### PR TITLE
extend props with proxy props

### DIFF
--- a/src/NamesakeLink.tsx
+++ b/src/NamesakeLink.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, LinkProps } from 'react-router-dom';
 
 import WithNamesake from './WithNamesake';
 
-export interface INamesakeLink {
+export interface INamesakeLink extends LinkProps {
   to: string;
   params?: {};
 }

--- a/src/NamesakeRoute.spec.tsx
+++ b/src/NamesakeRoute.spec.tsx
@@ -18,7 +18,7 @@ describe('NamesakeRoute', () => {
     const wrapper = mount(
       <Router>
         <Provider>
-          <NamesakeRoute path='home.path'></NamesakeRoute>
+          <NamesakeRoute exact path='home.path'></NamesakeRoute>
         </Provider>
       </Router>
     );

--- a/src/NamesakeRoute.tsx
+++ b/src/NamesakeRoute.tsx
@@ -1,9 +1,10 @@
 import { History } from 'history';
 import * as React from 'react';
+import { RouteProps } from 'react-router';
 import { Route } from 'react-router-dom';
 import { INamesakeRouterState, NamesakeConsumer } from './index';
 
-export interface IWithNamesakeRoute {
+export interface IWithNamesakeRoute extends RouteProps {
   path: string;
   params?: {
     [key: string]: any,


### PR DESCRIPTION
extend interfaces for `NamesakeLink` and `NamesakeRoute` with corresponding `react-router` prop interfaces