### PR TITLE
propsal: generate routes given a route config

### DIFF
--- a/src/generateRoutes.spec.ts
+++ b/src/generateRoutes.spec.ts
@@ -1,0 +1,110 @@
+import generateRoutes from './generateRoutes';
+
+describe('generateRoutes', () => {
+  it('should create a route with name', () => {
+    const routes = generateRoutes({
+      home: '/home',
+    });
+    expect(routes.home).toEqual('/home');
+  });
+
+  it('should pass through dynamic paths', () => {
+    const routes = generateRoutes({
+      'user': '/user/:userId',
+    });
+    expect(routes.user).toEqual('/user/:userId');
+  });
+
+  describe('nested routes', () => {
+    it('should not set the root path', () => {
+      const routes = generateRoutes({
+        user: {
+          children: {
+            book: { path: '/book' },
+            page: '/page',
+          },
+          path: '/user/:userId',
+        },
+      });
+      expect(routes.book).toBeUndefined();
+      expect(routes.page).toBeUndefined();
+    });
+
+    it('should a single level nested route', () => {
+      const routes = generateRoutes({
+        user: {
+          children: {
+            book: '/books/:bookId',
+            books: { path: '/books' },
+            nest: {
+              children: {
+                'bird': '/bird',
+              },
+              path: '/nest',
+            },
+          },
+          path: '/user/:userId',
+        },
+      });
+      expect(routes.user).toEqual('/user/:userId');
+    });
+
+    it('should have a nested child with a string path', () => {
+      const routes = generateRoutes({
+        user: {
+          children: {
+            book: '/books/:bookId',
+            books: { path: '/books' },
+            nest: {
+              children: {
+                'bird': '/bird',
+              },
+              path: '/nest',
+            },
+          },
+          path: '/user/:userId',
+        },
+      });
+      expect(routes['user.books']).toEqual('/user/:userId/books');
+    });
+
+    it('should have a deeply nested child route', () => {
+      const routes = generateRoutes({
+        user: {
+          children: {
+            book: '/books/:bookId',
+            books: { path: '/books' },
+            nest: {
+              children: {
+                'bird': '/bird',
+              },
+              path: '/nest',
+            },
+          },
+          path: '/user/:userId',
+        },
+      });
+      expect(routes['user.book']).toEqual('/user/:userId/books/:bookId');
+    });
+
+    it('should have a deeply nested child route with children', () => {
+      const routes = generateRoutes({
+        user: {
+          children: {
+            book: '/books/:bookId',
+            books: { path: '/books' },
+            nest: {
+              children: {
+                'bird': '/bird',
+              },
+              path: '/nest',
+            },
+          },
+          path: '/user/:userId',
+        },
+      });
+      expect(routes['user.nest.bird']).toEqual('/user/:userId/nest/bird');
+    });
+
+  });
+});

--- a/src/generateRoutes.ts
+++ b/src/generateRoutes.ts
@@ -2,24 +2,20 @@ export interface IRoutesConfig {
   [key: string]: string;
 }
 
-function reduce(obj, prefix=null, basePath=null) {
-  let result = {};
-  for (const key of Object.keys(obj)) {
+export default function generateRoutes(routes: {}, prefix?: string, basePath?: string): IRoutesConfig {
+  let result: IRoutesConfig = {};
+  for (const key of Object.keys(routes)) {
     const routeName = prefix ? `${prefix}.${key}` : key;
-    if (obj[key] instanceof Object) {
-      const path = prefix ? `${basePath}${obj[key].path}` : obj[key].path;
+    if (routes[key] instanceof Object) {
+      const path = prefix ? `${basePath}${routes[key].path}` : routes[key].path;
       result[routeName] = path;
 
-      const childRoutes = reduce(obj[key].children || {}, routeName, path);
+      const childRoutes = generateRoutes(routes[key].children || {}, routeName, path);
       result = {...result, ...childRoutes};
     } else {
-      const path = prefix ? `${basePath}${obj[key]}` : obj[key];
+      const path = prefix ? `${basePath}${routes[key]}` : routes[key];
       result[routeName] = path;
     }
   }
   return result;
-}
-
-export default function generateRoutes(routes: {}): IRoutesConfig {
-  return reduce(routes);
 }

--- a/src/generateRoutes.ts
+++ b/src/generateRoutes.ts
@@ -1,0 +1,25 @@
+export interface IRoutesConfig {
+  [key: string]: string;
+}
+
+function reduce(obj, prefix=null, basePath=null) {
+  let result = {};
+  for (const key of Object.keys(obj)) {
+    const routeName = prefix ? `${prefix}.${key}` : key;
+    if (obj[key] instanceof Object) {
+      const path = prefix ? `${basePath}${obj[key].path}` : obj[key].path;
+      result[routeName] = path;
+
+      const childRoutes = reduce(obj[key].children || {}, routeName, path);
+      result = {...result, ...childRoutes};
+    } else {
+      const path = prefix ? `${basePath}${obj[key]}` : obj[key];
+      result[routeName] = path;
+    }
+  }
+  return result;
+}
+
+export default function generateRoutes(routes: {}): IRoutesConfig {
+  return reduce(routes);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "outDir": "./lib",
     "typeRoots": ["typings", "node_modules/@types"],
-    "types": ["react", "react-router-dom", "react-router"],
+    "types": ["react", "react-router-dom", "react-router", "jest"],
     "jsx": "react"
   },
   "include": [


### PR DESCRIPTION
This is to add a way to specify nested routes without having to build the flat mapping yourself. This might be useful where a route is nested under serval parts, like the simple example of `/users/123/books` and `/stores/123/books`.


```javascript
// example of something you could possibly pass to `<NamesameRouter routes={routes} />`:
const routes = {
  user: {
    path: '/user/:userId',
    children: {
      book: '/books/:bookId',
      books: { path: '/books' },
      nest: {
        path: '/nest',
        children: {
          'bird': '/bird',
        },
      },
    },
  },
};

generateRoutes(routes);
/* =>
{
  user: '/user/:userId',
  'user.book': '/user/:userId/books/:bookId',
  'user.books': '/user/:userId/books',
  'user.nest': '/user/:userId/nest',
  'user.nest.bird': '/user/:userId/nest/bird',
};
*/
```

I'm not sure this is useful or not. Probably not.